### PR TITLE
Fix runtime crash by adding Jinja2 dependency

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,4 +46,3 @@ def generate_text(prompt: Prompt):
 @app.get("/", response_class=HTMLResponse)
 def landing(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
-n

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn[standard]
 transformers
+
+jinja2


### PR DESCRIPTION
## Summary
- fix stray character at end of `app/main.py`
- add `jinja2` to `requirements.txt` so templates render properly

## Testing
- `python -m compileall app`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684b6e3338c48326aebdc72ea19d9337