### PR TITLE
Implement voice activation toggle with VAD

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,12 @@ def landing(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 
+@app.get("/settings", response_class=HTMLResponse)
+def settings_page(request: Request):
+    """Render the settings page."""
+    return templates.TemplateResponse("settings.html", {"request": request})
+
+
 @app.websocket("/ws/audio")
 async def audio_stream(websocket: WebSocket):
     """Receive audio chunks and return dummy transcription."""

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -6,17 +6,24 @@ let mediaRecorder = null;
 let audioContext = null;
 let analyser = null;
 let animationId = null;
+let voiceActivated = false;
+let vadTimeout = null;
+const vadThreshold = 0.02; // simple RMS threshold
+const silenceTimeout = 1000; // ms
+let micStream = null;
 
 function setup() {
     micButton = document.getElementById('mic-button');
     visualizerCanvas = document.getElementById('visualizer');
     if (!micButton) return;
 
+    voiceActivated = localStorage.getItem('voiceActivated') === 'true';
+
     micButton.addEventListener('click', toggleMic);
 }
 
 async function toggleMic() {
-    if (mediaRecorder && mediaRecorder.state === 'recording') {
+    if (audioContext) {
         stopRecording();
     } else {
         startRecording();
@@ -25,28 +32,16 @@ async function toggleMic() {
 
 async function startRecording() {
     try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
         audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        const source = audioContext.createMediaStreamSource(stream);
+        const source = audioContext.createMediaStreamSource(micStream);
         analyser = audioContext.createAnalyser();
         source.connect(analyser);
 
-        mediaRecorder = new MediaRecorder(stream);
-        mediaRecorder.addEventListener('dataavailable', event => {
-            if (event.data.size > 0 && ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(event.data);
-            }
-        });
-        mediaRecorder.start(250); // send in chunks every 250ms
-
-        ws = new WebSocket(`ws://${window.location.host}/ws/audio`);
-        ws.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            appendMessage(data.text);
-        };
-
         visualize();
-        micButton.classList.add('active');
+        if (!voiceActivated) {
+            beginStreaming(micStream);
+        }
     } catch (err) {
         console.error('Mic access denied:', err);
         alert('Microphone access denied.');
@@ -54,12 +49,52 @@ async function startRecording() {
 }
 
 function stopRecording() {
-    if (mediaRecorder) mediaRecorder.stop();
-    if (ws) ws.close();
+    stopStreaming();
     cancelAnimationFrame(animationId);
-    if (audioContext) audioContext.close();
+    if (audioContext) {
+        audioContext.close();
+        audioContext = null;
+    }
+    if (micStream) {
+        micStream.getTracks().forEach(t => t.stop());
+        micStream = null;
+    }
+    if (vadTimeout) {
+        clearTimeout(vadTimeout);
+        vadTimeout = null;
+    }
+}
+
+function beginStreaming(stream) {
+    if (mediaRecorder) return;
+    ws = new WebSocket(`ws://${window.location.host}/ws/audio`);
+    ws.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        appendMessage(data.text);
+    };
+
+    mediaRecorder = new MediaRecorder(stream);
+    mediaRecorder.addEventListener('dataavailable', (event) => {
+        if (event.data.size > 0 && ws.readyState === WebSocket.OPEN) {
+            ws.send(event.data);
+        }
+    });
+    mediaRecorder.start(250);
+    micButton.classList.add('active');
+}
+
+function stopStreaming() {
+    if (mediaRecorder) {
+        mediaRecorder.stop();
+        mediaRecorder = null;
+    }
+    if (ws) {
+        ws.close();
+        ws = null;
+    }
     micButton.classList.remove('active');
 }
+
 
 function visualize() {
     const canvasCtx = visualizerCanvas.getContext('2d');
@@ -70,6 +105,27 @@ function visualize() {
     function draw() {
         animationId = requestAnimationFrame(draw);
         analyser.getByteTimeDomainData(dataArray);
+
+        if (voiceActivated) {
+            let sum = 0;
+            for (let i = 0; i < bufferLength; i++) {
+                const v = (dataArray[i] - 128) / 128;
+                sum += v * v;
+            }
+            const rms = Math.sqrt(sum / bufferLength);
+            if (rms > vadThreshold) {
+                if (!mediaRecorder) beginStreaming(micStream);
+                if (vadTimeout) {
+                    clearTimeout(vadTimeout);
+                    vadTimeout = null;
+                }
+            } else if (mediaRecorder && !vadTimeout) {
+                vadTimeout = setTimeout(() => {
+                    stopStreaming();
+                }, silenceTimeout);
+            }
+        }
+
         canvasCtx.fillStyle = '#f3f3f3';
         canvasCtx.fillRect(0, 0, visualizerCanvas.width, visualizerCanvas.height);
         canvasCtx.lineWidth = 2;

--- a/app/static/settings.js
+++ b/app/static/settings.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('voice-toggle');
+    if (!toggle) return;
+    toggle.checked = localStorage.getItem('voiceActivated') === 'true';
+    toggle.addEventListener('change', () => {
+        localStorage.setItem('voiceActivated', toggle.checked);
+    });
+});

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -30,6 +30,12 @@ body {
     cursor: pointer;
     margin-bottom: 20px;
 }
+.settings-link {
+    display: block;
+    margin-bottom: 20px;
+    color: #000;
+    text-decoration: none;
+}
 .conversations h3 {
     margin: 15px 0 5px;
     font-size: 0.9rem;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,6 +13,7 @@
     <aside class="sidebar">
         <div class="logo">AnyChat</div>
         <button class="new-chat">+ New chat</button>
+        <a href="/settings" class="settings-link">Settings</a>
         <div class="conversations">
             <h3>Today</h3>
             <ul>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Settings</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<div class="container" style="padding:20px;">
+    <h1>Settings</h1>
+    <label>
+        <input type="checkbox" id="voice-toggle">
+        Voice Activation
+    </label>
+    <p><a href="/">Back to chat</a></p>
+</div>
+<script src="/static/settings.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a settings page with a 'Voice Activation' checkbox
- link to the settings page from the sidebar
- implement client‑side voice activity detection and streaming logic
- indicate streaming state via mic button
- expose new `/settings` route on the server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca988eb508326968b75b7a9870630