### PR TITLE
Clean up placeholder UI elements

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -36,22 +36,6 @@ body {
     color: #000;
     text-decoration: none;
 }
-.conversations h3 {
-    margin: 15px 0 5px;
-    font-size: 0.9rem;
-}
-.conversations ul {
-    list-style: none;
-    padding: 0;
-}
-.conversations li {
-    padding: 5px 0;
-    border-radius: 6px;
-}
-.conversations li.active {
-    background: #fff;
-    padding-left: 5px;
-}
 .profile {
     display: flex;
     flex-direction: column;
@@ -64,21 +48,6 @@ body {
     margin-top: 8px;
     font-weight: 600;
 }
-.profile button.more {
-    background: none;
-    border: none;
-    cursor: pointer;
-    margin: 5px 0;
-}
-.profile button.upgrade {
-    background: #000;
-    color: #fff;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 8px;
-    cursor: pointer;
-    margin-top: 10px;
-}
 .chat-area {
     flex: 1;
     background: #fff;
@@ -89,19 +58,12 @@ body {
 }
 .chat-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: flex-start;
 }
 .chat-header h1 {
     margin: 0;
     font-size: 1.2rem;
-}
-.chat-header .actions button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    margin-left: 10px;
-    font-size: 1.1rem;
 }
 .messages {
     flex: 1;
@@ -121,26 +83,6 @@ body {
 .message.assistant {
     background: #fff;
     border: 1px solid #eee;
-}
-.toggle-prompts,
-.regenerate {
-    background: #ffdce5;
-    border: none;
-    padding: 8px 12px;
-    border-radius: 8px;
-    cursor: pointer;
-    margin: 10px 0;
-}
-.quick-prompts {
-    display: flex;
-    gap: 10px;
-}
-.quick-prompts button {
-    background: #fff;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    padding: 6px 10px;
-    cursor: pointer;
 }
 .input-area {
     display: flex;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,22 +14,9 @@
         <div class="logo">AnyChat</div>
         <button class="new-chat">+ New chat</button>
         <a href="/settings" class="settings-link">Settings</a>
-        <div class="conversations">
-            <h3>Today</h3>
-            <ul>
-                <li>Web Design Workflow</li>
-                <li class="active">Weather Dynamics</li>
-            </ul>
-            <h3>Previous 7 days</h3>
-            <ul>
-                <li>Photo generation</li>
-            </ul>
-        </div>
         <div class="profile">
             <img src="https://placehold.co/40x40" alt="avatar" class="avatar">
             <span class="name">Emily</span>
-            <button class="more">...</button>
-            <button class="upgrade">Upgrade to Pro</button>
         </div>
     </aside>
     <main class="chat-area">
@@ -40,26 +27,8 @@
         </div>
         <header class="chat-header">
             <h1>Weather Dynamics</h1>
-            <div class="actions">
-                <button title="Plugins">&#128295;</button>
-                <button title="Share">&#128257;</button>
-                <button title="Delete">&#128465;</button>
-            </div>
         </header>
         <div class="messages">
-            <div class="message user">Why does the weather not just stay the same?</div>
-            <div class="message assistant">
-                <h2>Atmospheric Dynamics</h2>
-                <p>Large-scale movement of air causes continual changes in pressure and temperature.</p>
-                <h2>Solar Influence</h2>
-                <p>The sun heats the earth unevenly creating cycles that drive different weather patterns.</p>
-            </div>
-            <button class="toggle-prompts">Hide Prompts</button>
-            <div class="quick-prompts">
-                <button>Show me the temperature today</button>
-                <button>Why does it rain</button>
-            </div>
-            <button class="regenerate">Regenerate</button>
         </div>
         <form class="input-area">
             <input type="text" placeholder="Send your message" />


### PR DESCRIPTION
## Summary
- remove unused sidebar conversation list
- strip placeholder action buttons from chat header
- delete sample messages and quick prompts
- drop unused CSS rules

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684cf560ac0883268e40cf6d1c26dda4