### PR TITLE
Implement new UI layout with navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project provides a simple FastAPI interface for interacting with a language
    docker-compose up --build
    ```
    
-2. Open your browser at `http://localhost:8000` to see the welcome message.
+2. Open your browser at `http://localhost:8000` to see the chat interface. Use the
+   navigation menu to access the Pipeline, Testing and Settings pages.
 
 3. Send a POST request to `http://localhost:8000/generate` with JSON body `{ "text": "Your prompt" }` to generate text.
 

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -4,6 +4,44 @@ body {
     margin: 0;
     padding: 0;
 }
+
+.top-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    padding: 10px 20px;
+    border-bottom: 1px solid #eee;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+.nav-menu a {
+    margin-left: 15px;
+    color: #000;
+    text-decoration: none;
+}
+.nav-menu a.active {
+    font-weight: 600;
+}
+.voice-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #ccc;
+    margin-left: auto;
+    margin-right: 10px;
+}
+.voice-indicator.active {
+    animation: pulse 1s infinite;
+    background: #6200ee;
+}
+@keyframes pulse {
+    0% { box-shadow: 0 0 0 0 rgba(98,0,238,0.4); }
+    70% { box-shadow: 0 0 0 10px rgba(98,0,238,0); }
+    100% { box-shadow: 0 0 0 0 rgba(98,0,238,0); }
+}
+
 .container {
     display: flex;
     height: 100vh;
@@ -104,12 +142,38 @@ body {
     border-radius: 0 20px 20px 0;
     cursor: pointer;
 }
+.input-area .speaker {
+    margin-left: 10px;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+}
 .input-area #mic-button {
     margin-left: 10px;
     border-radius: 50%;
     width: 40px;
     height: 40px;
     padding: 0;
+}
+.mic-wrapper {
+    position: relative;
+    display: inline-block;
+}
+.voice-ring {
+    position: absolute;
+    top: -5px;
+    left: -5px;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    pointer-events: none;
+    box-shadow: 0 0 0 0 rgba(98,0,238,0.4);
+    opacity: 0;
+}
+.voice-ring.active {
+    animation: pulse 1s infinite;
+    opacity: 1;
 }
 .input-area #mic-button.active {
     background: #6200ee;
@@ -130,6 +194,14 @@ body {
     max-height: 120px;
     overflow-y: auto;
     position: relative;
+}
+.ai-response {
+    border: 2px solid #eee;
+    background: #fff;
+    padding: 10px;
+    margin-bottom: 10px;
+    max-height: 150px;
+    overflow-y: auto;
 }
 .stt-container h2 {
     margin-top: 0;
@@ -207,4 +279,52 @@ body {
 .settings-wrapper a {
     color: #6200ee;
     text-decoration: none;
+}
+
+/* Pipeline and Testing */
+.pipeline-wrapper, .testing-wrapper {
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+    background: #fff;
+    border: 1px solid #eee;
+    border-radius: 8px;
+}
+.pipeline-diagram {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-bottom: 20px;
+}
+.pipeline-diagram .node {
+    padding: 10px 15px;
+    background: #f3f3f3;
+    border-radius: 6px;
+}
+.pipeline-diagram .arrow {
+    font-size: 1.2rem;
+}
+.pipeline-logs {
+    max-height: 150px;
+    overflow-y: auto;
+    border-top: 1px solid #eee;
+    padding-top: 10px;
+}
+.tabs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+.tab {
+    padding: 6px 12px;
+    border: 1px solid #ccc;
+    background: #f9f9f9;
+    cursor: pointer;
+    border-radius: 4px;
+}
+.tab.active {
+    background: #6200ee;
+    color: #fff;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,31 +9,41 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
+<header class="top-bar">
+    <h1>AnyChat AI</h1>
+    <div class="voice-indicator" id="voice-indicator"></div>
+    <nav class="nav-menu">
+        <a href="/" class="active">Chat</a>
+        <a href="/pipeline">Pipeline</a>
+        <a href="/testing">Testing</a>
+        <a href="/settings">Settings</a>
+    </nav>
+</header>
 <div class="container">
     <aside class="sidebar">
-        <div class="logo">AnyChat</div>
-        <button class="new-chat">+ New chat</button>
-        <a href="/settings" class="settings-link">Settings</a>
-        <div class="profile">
-            <img src="https://placehold.co/40x40" alt="avatar" class="avatar">
-            <span class="name">Emily</span>
-        </div>
+        <div class="logo">AnyChat AI</div>
+        <button class="new-chat">+ New Chat</button>
+        <div class="conversation-list"></div>
     </aside>
     <main class="chat-area">
         <div class="stt-container">
-            <h2>You said:</h2>
+            <h2>🎤 Your Speech</h2>
             <div id="stt-output" class="stt-text"></div>
             <div id="tooltip" class="tooltip" style="display:none;"></div>
         </div>
-        <header class="chat-header">
-            <h1>Weather Dynamics</h1>
-        </header>
-        <div class="messages">
+        <div class="ai-response">
+            <h2>🧠 AI Response</h2>
+            <div id="ai-output"></div>
         </div>
+        <div class="messages"></div>
         <form class="input-area">
             <input type="text" placeholder="Send your message" />
             <button type="submit">&#128073;</button>
-            <button type="button" id="mic-button" title="Toggle microphone">🎤</button>
+            <div class="mic-wrapper">
+                <button type="button" id="mic-button" title="Toggle microphone">🎤</button>
+                <div id="voice-ring" class="voice-ring"></div>
+            </div>
+            <button type="button" id="speaker" class="speaker" title="Audio playback">🔊</button>
         </form>
         <canvas id="visualizer" width="300" height="80"></canvas>
         <footer class="footer">

--- a/app/templates/pipeline.html
+++ b/app/templates/pipeline.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pipeline</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header class="top-bar">
+    <h1>AnyChat AI</h1>
+    <nav class="nav-menu">
+        <a href="/">Chat</a>
+        <a href="/pipeline" class="active">Pipeline</a>
+        <a href="/testing">Testing</a>
+        <a href="/settings">Settings</a>
+    </nav>
+</header>
+<div class="pipeline-wrapper">
+    <h2>⚙️ AI Pipeline Visualization</h2>
+    <div class="pipeline-diagram">
+        <div class="node">Microphone</div>
+        <div class="arrow">→</div>
+        <div class="node">Speech-to-Text</div>
+        <div class="arrow">→</div>
+        <div class="node">LLM</div>
+        <div class="arrow">→</div>
+        <div class="node">Text-to-Speech</div>
+        <div class="arrow">→</div>
+        <div class="node">Speaker</div>
+    </div>
+    <aside class="pipeline-logs">
+        <h3>Logs</h3>
+        <ul id="log-list"></ul>
+    </aside>
+</div>
+<script src="/static/app.js"></script>
+</body>
+</html>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -7,6 +7,15 @@
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
+<header class="top-bar">
+    <h1>AnyChat AI</h1>
+    <nav class="nav-menu">
+        <a href="/">Chat</a>
+        <a href="/pipeline">Pipeline</a>
+        <a href="/testing">Testing</a>
+        <a href="/settings" class="active">Settings</a>
+    </nav>
+</header>
 <div class="settings-wrapper">
     <h1>Settings</h1>
     <label>
@@ -28,7 +37,6 @@
             <option value="temporary">Temporary</option>
         </select>
     </label>
-    <p><a href="/">Back to chat</a></p>
 </div>
 <script src="/static/settings.js"></script>
 </body>

--- a/app/templates/testing.html
+++ b/app/templates/testing.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Model Testing</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+<header class="top-bar">
+    <h1>AnyChat AI</h1>
+    <nav class="nav-menu">
+        <a href="/">Chat</a>
+        <a href="/pipeline">Pipeline</a>
+        <a href="/testing" class="active">Testing</a>
+        <a href="/settings">Settings</a>
+    </nav>
+</header>
+<div class="testing-wrapper">
+    <h2>🧪 Model Testing</h2>
+    <div class="tabs">
+        <button class="tab active" data-target="stt-tab">Speech-to-Text</button>
+        <button class="tab" data-target="tts-tab">Text-to-Speech</button>
+        <button class="tab" data-target="llm-tab">LLM</button>
+    </div>
+    <div class="tab-content" id="stt-tab">
+        <button id="test-mic" class="mic-btn">🎤</button>
+        <canvas id="test-wave" width="300" height="80"></canvas>
+        <div id="test-transcript" class="test-transcript"></div>
+    </div>
+    <div class="tab-content" id="tts-tab" style="display:none;">
+        <input type="text" id="tts-input" placeholder="Type something to speak..." />
+        <button id="tts-play">Play</button>
+        <div id="tts-status"></div>
+    </div>
+    <div class="tab-content" id="llm-tab" style="display:none;">
+        <textarea id="llm-prompt" rows="3" placeholder="Prompt"></textarea>
+        <button id="llm-send">Send</button>
+        <pre id="llm-response"></pre>
+    </div>
+</div>
+<script src="/static/app.js"></script>
+<script>
+// simple tabs
+const tabs = document.querySelectorAll('.tab');
+const contents = document.querySelectorAll('.tab-content');
+for (const t of tabs) {
+  t.addEventListener('click', () => {
+    tabs.forEach(b => b.classList.remove('active'));
+    t.classList.add('active');
+    contents.forEach(c => c.style.display = c.id === t.dataset.target ? 'block' : 'none');
+  });
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign index page with a top bar, sidebar and new transcription/response areas
- add settings, pipeline, and testing pages with shared navigation menu
- style top bar, navigation, voice indicator, and new pages
- add voice indicator logic to app.js
- update FastAPI routes and README instructions
- log whisper transcription text and display it in the chat messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684def0f56b08326b261e329182e4cf3