### PR TITLE
Use Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ElaraLM
 
-This project provides a simple FastAPI interface for interacting with a language model using Hugging Face transformers. The application is containerized with Docker for easy deployment.
+This project provides a simple FastAPI interface for interacting with a language model using Hugging Face transformers. The application is containerized with Docker for easy deployment and runs on **Python&nbsp;3.11**, which allows installing Coqui TTS.
 
 ## Quick Start
 
@@ -10,17 +10,17 @@ This project provides a simple FastAPI interface for interacting with a language
    docker-compose up --build
    ```
    
-2. Open your browser at `http://localhost:8000` to see the chat interface. Use the
+2. Open your browser at `http://localhost:8081` to see the chat interface. Use the
    navigation menu to access the Pipeline, Testing and Settings pages.
 
-3. Send a POST request to `http://localhost:8000/generate` with JSON body `{ "text": "Your prompt" }` to generate text.
+3. Send a POST request to `http://localhost:8081/generate` with JSON body `{ "text": "Your prompt" }` to generate text.
 
 The UI now includes a microphone button for streaming audio directly to the server. Clicking the button will request microphone permissions and visualize the incoming audio while transcribed text is displayed live in the chat.
 Transcriptions are labeled with "You said:" and words with low confidence scores are highlighted. Hover over a segment to see the recognition confidence and timestamp or replay the audio.
 
 ## Development
 
-Install dependencies locally:
+Install dependencies locally (Python 3.11):
 
 ```bash
 python -m venv venv


### PR DESCRIPTION
## Summary
- update Docker base image to Python 3.11
- mention Python 3.11 in README
- update README links to use port 8081

## Testing
- `python3 -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ef8d6e4bc83269f9bcd50cdc8c4e2