### PR TITLE
Add dynamic model selection UI and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This project provides a simple FastAPI interface for interacting with a language
 The UI now includes a microphone button for streaming audio directly to the server. Clicking the button will request microphone permissions and visualize the incoming audio while transcribed text is displayed live in the chat.
 Transcriptions are labeled with "You said:" and words with low confidence scores are highlighted. Hover over a segment to see the recognition confidence and timestamp or replay the audio.
 
+## Dynamic Model Selection
+
+The Settings page allows reloading and selecting models for **TTS**, **STT**, and **LLM**. Place models under `models/tts` or `models/stt`, or use locally installed Ollama models. Remote LLMStudio models can be configured with an API URL and key. Choices are saved to `config.json`.
+
 ## Development
 
 Install dependencies locally (Python 3.11):

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,0 +1,115 @@
+import os
+import subprocess
+from typing import List
+
+import httpx
+
+OLLAMA_URL = os.environ.get('OLLAMA_URL', 'http://localhost:11434')
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config.json')
+
+_current_source = 'local'
+_current_model: str | None = None
+_llmstudio_url: str | None = os.environ.get('LLMSTUDIO_URL')
+_llmstudio_key: str | None = os.environ.get('LLMSTUDIO_KEY')
+
+
+def _save_config() -> None:
+    try:
+        data = {
+            'source': _current_source,
+            'model': _current_model,
+            'llmstudio_url': _llmstudio_url,
+            'llmstudio_key': _llmstudio_key,
+        }
+        with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+            import json
+            json.dump({'llm': data}, f)
+    except Exception:
+        pass
+
+
+def _load_config() -> None:
+    global _current_source, _current_model, _llmstudio_url, _llmstudio_key
+    try:
+        import json
+        with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+            cfg = json.load(f).get('llm', {})
+            _current_source = cfg.get('source', 'local')
+            _current_model = cfg.get('model')
+            _llmstudio_url = cfg.get('llmstudio_url')
+            _llmstudio_key = cfg.get('llmstudio_key')
+    except Exception:
+        pass
+
+
+_load_config()
+
+
+async def list_local_models() -> List[str]:
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            resp = await client.get(f'{OLLAMA_URL}/api/tags')
+            resp.raise_for_status()
+            return [m['name'] for m in resp.json().get('models', [])]
+    except Exception:
+        try:
+            out = subprocess.check_output(['ollama', 'list'], text=True)
+            return [line.split(':')[0] for line in out.splitlines() if line]
+        except Exception:
+            return []
+
+
+async def list_remote_models() -> List[str]:
+    if not _llmstudio_url:
+        return []
+    try:
+        headers = {'Authorization': f'Bearer {_llmstudio_key}'} if _llmstudio_key else {}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(_llmstudio_url.rstrip('/') + '/models', headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get('models', [])
+    except Exception:
+        return []
+
+
+def select_model(source: str, name: str, url: str | None = None, key: str | None = None) -> None:
+    global _current_source, _current_model, _llmstudio_url, _llmstudio_key
+    _current_source = source
+    _current_model = name
+    if url:
+        _llmstudio_url = url
+    if key:
+        _llmstudio_key = key
+    _save_config()
+
+
+async def generate(prompt: str) -> str:
+    if _current_source == 'remote' and _llmstudio_url:
+        headers = {'Authorization': f'Bearer {_llmstudio_key}'} if _llmstudio_key else {}
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(
+                    _llmstudio_url.rstrip('/') + '/v1/chat/completions',
+                    headers=headers,
+                    json={'model': _current_model, 'messages': [{'role': 'user', 'content': prompt}]}
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                choice = data.get('choices', [{}])[0]
+                return choice.get('message', {}).get('content', '').strip()
+        except Exception:
+            pass
+    else:
+        url = f'{OLLAMA_URL}/api/generate'
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(url, json={'model': _current_model or 'llama3', 'prompt': prompt})
+                resp.raise_for_status()
+                data = resp.json()
+                return data.get('response', data.get('generated_text', '')).strip()
+        except Exception:
+            pass
+    return ''
+
+

--- a/app/static/settings.js
+++ b/app/static/settings.js
@@ -78,4 +78,60 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    const sttSelect = document.getElementById('stt-select');
+    const reloadStt = document.getElementById('reload-stt');
+
+    async function loadSttModels() {
+        const res = await fetch('/stt/models');
+        const data = await res.json();
+        if (!sttSelect) return;
+        sttSelect.innerHTML = '';
+        data.models.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            if (data.selected === m) opt.selected = true;
+            sttSelect.appendChild(opt);
+        });
+    }
+
+    if (sttSelect) {
+        loadSttModels();
+        sttSelect.addEventListener('change', async () => {
+            await fetch('/stt/select?name=' + encodeURIComponent(sttSelect.value), { method: 'POST' });
+        });
+    }
+    if (reloadStt) reloadStt.addEventListener('click', loadSttModels);
+
+    const llmSelect = document.getElementById('llm-select');
+    const llmSource = document.getElementById('llm-source');
+    const reloadLlm = document.getElementById('reload-llm');
+
+    async function loadLlmModels() {
+        const source = llmSource ? llmSource.value : 'local';
+        const res = await fetch('/llm/models?source=' + source);
+        const data = await res.json();
+        if (!llmSelect) return;
+        llmSelect.innerHTML = '';
+        data.models.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            llmSelect.appendChild(opt);
+        });
+    }
+
+    if (llmSource) llmSource.addEventListener('change', loadLlmModels);
+    if (llmSelect) {
+        loadLlmModels();
+        llmSelect.addEventListener('change', async () => {
+            await fetch('/llm/select', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ source: llmSource ? llmSource.value : 'local', name: llmSelect.value })
+            });
+        });
+    }
+    if (reloadLlm) reloadLlm.addEventListener('click', loadLlmModels);
 });

--- a/app/stt.py
+++ b/app/stt.py
@@ -1,0 +1,55 @@
+import os
+import json
+from typing import List, Tuple
+
+import whisper
+
+MODELS_DIR = os.path.join(os.path.dirname(__file__), '..', 'models', 'stt')
+_current_model: str | None = None
+_engine: whisper.Whisper | None = None
+
+
+def _load_config(name: str) -> dict:
+    path = os.path.join(MODELS_DIR, name, 'config.json')
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def list_models() -> List[str]:
+    if not os.path.isdir(MODELS_DIR):
+        return []
+    return [n for n in os.listdir(MODELS_DIR)
+            if os.path.isfile(os.path.join(MODELS_DIR, n, 'config.json'))]
+
+
+def select_model(name: str) -> None:
+    global _engine, _current_model
+    if name not in list_models():
+        raise ValueError(f"Model '{name}' not found")
+    cfg = _load_config(name)
+    model_name = cfg.get('model_name', name)
+    _engine = whisper.load_model(model_name)
+    _current_model = name
+
+
+def get_selected_model() -> str | None:
+    return _current_model
+
+
+def transcribe_audio(samples) -> Tuple[str, float]:
+    global _engine
+    if _engine is None:
+        models = list_models()
+        if models:
+            select_model(models[0])
+        else:
+            _engine = whisper.load_model('base')
+            _current_model = 'base'
+    result = _engine.transcribe(samples, fp16=False)
+    text = result.get('text', '').strip()
+    confidence = float(result.get('avg_logprob', -10))
+    return text, confidence
+

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -43,6 +43,20 @@
         <button id="reload-tts" type="button">Reload Models</button>
         <button id="add-tts" type="button">Add Model</button>
     </label>
+    <label>
+        Select Speech-to-Text Model
+        <select id="stt-select"></select>
+        <button id="reload-stt" type="button">Reload Models</button>
+    </label>
+    <label>
+        LLM Source
+        <select id="llm-source">
+            <option value="local">Local (Ollama)</option>
+            <option value="remote">Remote</option>
+        </select>
+        <select id="llm-select"></select>
+        <button id="reload-llm" type="button">Reload</button>
+    </label>
 </div>
 <script src="/static/settings.js"></script>
 </body>

--- a/models/stt/en/config.json
+++ b/models/stt/en/config.json
@@ -1,0 +1,1 @@
+{"model_name": "base"}


### PR DESCRIPTION
## Summary
- implement new STT and LLM management modules
- expose APIs to list/select STT and LLM models
- extend settings UI and JS to handle STT and LLM choices
- add minimal Whisper model config example
- document dynamic model selection feature

## Testing
- `python -m py_compile app/main.py app/llm.py app/stt.py app/tts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851955fafa88326b8637a19d6644fd7