### PR TITLE
Improve settings layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -336,3 +336,46 @@ body {
     background: #6200ee;
     color: #fff;
 }
+
+.settings-wrapper {
+    max-width: 600px;
+    margin: 40px auto;
+    padding: 30px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+    font-size: 1rem;
+}
+
+.settings-wrapper h1 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+}
+
+.settings-wrapper label {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: 20px;
+    gap: 8px;
+}
+
+.settings-wrapper select,
+.settings-wrapper input[type="number"],
+.settings-wrapper button {
+    padding: 8px 12px;
+    font-size: 1rem;
+    margin-right: 10px;
+}
+
+.settings-wrapper input[type="checkbox"] {
+    margin-right: 8px;
+    transform: scale(1.2);
+}
+
+.settings-section {
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #eee;
+}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -18,45 +18,64 @@
 </header>
 <div class="settings-wrapper">
     <h1>Settings</h1>
-    <label>
-        <input type="checkbox" id="voice-toggle">
-        Voice Activation
-    </label>
-    <label>
-        Confidence Threshold
-        <input type="number" id="confidence-threshold" min="0" max="1" step="0.05">
-    </label>
-    <label>
-        <input type="checkbox" id="feedback-toggle" checked>
-        Enable Transcription Feedback
-    </label>
-    <label>
-        Feedback Mode
-        <select id="feedback-mode">
-            <option value="persistent">Persistent</option>
-            <option value="temporary">Temporary</option>
-        </select>
-    </label>
-    <label>
-        Select Text-to-Speech Model
-        <select id="tts-select"></select>
-        <button id="reload-tts" type="button">Reload Models</button>
-        <button id="add-tts" type="button">Add Model</button>
-    </label>
-    <label>
-        Select Speech-to-Text Model
-        <select id="stt-select"></select>
-        <button id="reload-stt" type="button">Reload Models</button>
-    </label>
-    <label>
-        LLM Source
-        <select id="llm-source">
-            <option value="local">Local (Ollama)</option>
-            <option value="remote">Remote</option>
-        </select>
-        <select id="llm-select"></select>
-        <button id="reload-llm" type="button">Reload</button>
-    </label>
+
+    <div class="settings-section">
+        <label>
+            <input type="checkbox" id="voice-toggle">
+            Voice Activation
+        </label>
+        <label>
+            Confidence Threshold
+            <input type="number" id="confidence-threshold" min="0" max="1" step="0.05">
+        </label>
+    </div>
+
+    <div class="settings-section">
+        <label>
+            <input type="checkbox" id="feedback-toggle" checked>
+            Enable Transcription Feedback
+        </label>
+        <label>
+            Feedback Mode
+            <select id="feedback-mode">
+                <option value="persistent">Persistent</option>
+                <option value="temporary">Temporary</option>
+            </select>
+        </label>
+    </div>
+
+    <div class="settings-section">
+        <label>
+            Select Text-to-Speech Model
+            <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                <select id="tts-select"></select>
+                <button id="reload-tts" type="button">Reload Models</button>
+                <button id="add-tts" type="button">Add Model</button>
+            </div>
+        </label>
+
+        <label>
+            Select Speech-to-Text Model
+            <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                <select id="stt-select"></select>
+                <button id="reload-stt" type="button">Reload Models</button>
+            </div>
+        </label>
+    </div>
+
+    <div class="settings-section">
+        <label>
+            LLM Source
+            <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                <select id="llm-source">
+                    <option value="local">Local (Ollama)</option>
+                    <option value="remote">Remote</option>
+                </select>
+                <select id="llm-select"></select>
+                <button id="reload-llm" type="button">Reload</button>
+            </div>
+        </label>
+    </div>
 </div>
 <script src="/static/settings.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- tweak settings page HTML structure for clearer sectioning
- override settings CSS to improve spacing and readability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852499c78108326a30f698db04513f0