### PR TITLE
Simplify STT usage and UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -234,17 +234,6 @@ async def tts_stream(websocket: WebSocket):
         logger.info("/ws/tts disconnected")
 
 
-@app.get("/stt/models")
-def get_stt_models():
-    """Return available STT model names and current selection."""
-    return {"models": stt.list_models(), "selected": stt.get_selected_model()}
-
-
-@app.post("/stt/select")
-def select_stt_model(name: str):
-    """Set the active STT model."""
-    stt.select_model(name)
-    return {"selected": name}
 
 
 class LLMSelect(BaseModel):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -29,9 +29,9 @@ let speakWs = null;
 let currentAudio = null;
 
 function setup() {
-    micButton = document.getElementById('mic-button');
-    visualizerCanvas = document.getElementById('visualizer');
-    sttOutput = document.getElementById('stt-output');
+    micButton = document.getElementById('mic-button') || document.getElementById('test-mic');
+    visualizerCanvas = document.getElementById('visualizer') || document.getElementById('test-wave');
+    sttOutput = document.getElementById('stt-output') || document.getElementById('test-transcript');
     tooltip = document.getElementById('tooltip');
     voiceIndicator = document.getElementById('voice-indicator');
     voiceRing = document.getElementById('voice-ring');
@@ -259,6 +259,10 @@ function appendTranscription(text, confidence, timestamp, audioB64) {
     feedbackEnabled = localStorage.getItem('feedbackEnabled') !== 'false';
     feedbackMode = localStorage.getItem('feedbackMode') || feedbackMode;
 
+    if (sttOutput.tagName === 'TEXTAREA') {
+        sttOutput.value += text + ' ';
+        return;
+    }
     const span = document.createElement('span');
     if (feedbackEnabled && confidence !== undefined && confidence < feedbackThreshold) {
         span.classList.add('uncertain');

--- a/app/static/settings.js
+++ b/app/static/settings.js
@@ -129,30 +129,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    const sttSelect = document.getElementById('stt-select');
-    const reloadStt = document.getElementById('reload-stt');
-
-    async function loadSttModels() {
-        const res = await fetch('/stt/models');
-        const data = await res.json();
-        if (!sttSelect) return;
-        sttSelect.innerHTML = '';
-        data.models.forEach(m => {
-            const opt = document.createElement('option');
-            opt.value = m;
-            opt.textContent = m;
-            if (data.selected === m) opt.selected = true;
-            sttSelect.appendChild(opt);
-        });
-    }
-
-    if (sttSelect) {
-        loadSttModels();
-        sttSelect.addEventListener('change', async () => {
-            await fetch('/stt/select?name=' + encodeURIComponent(sttSelect.value), { method: 'POST' });
-        });
-    }
-    if (reloadStt) reloadStt.addEventListener('click', loadSttModels);
 
     const llmSelect = document.getElementById('llm-select');
     const llmSource = document.getElementById('llm-source');

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -210,6 +210,13 @@ body {
     z-index: 10;
 }
 
+.test-transcript {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 10px;
+    resize: vertical;
+}
+
 .stt-text button.replay {
     background: none;
     border: none;

--- a/app/stt.py
+++ b/app/stt.py
@@ -1,60 +1,18 @@
-import os
-import json
-from typing import List, Tuple
+import logging
+from typing import Tuple
 
 import whisper
-import logging
 
-MODELS_DIR = os.path.join(os.path.dirname(__file__), "..", "models", "stt")
-_current_model: str | None = None
 _engine: whisper.Whisper | None = None
-
 logger = logging.getLogger(__name__)
 
 
-def _load_config(name: str) -> dict:
-    path = os.path.join(MODELS_DIR, name, "config.json")
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
-        return {}
-
-
-def list_models() -> List[str]:
-    if not os.path.isdir(MODELS_DIR):
-        return []
-    return [
-        n
-        for n in os.listdir(MODELS_DIR)
-        if os.path.isfile(os.path.join(MODELS_DIR, n, "config.json"))
-    ]
-
-
-def select_model(name: str) -> None:
-    global _engine, _current_model
-    if name not in list_models():
-        raise ValueError(f"Model '{name}' not found")
-    cfg = _load_config(name)
-    model_name = cfg.get("model_name", name)
-    _engine = whisper.load_model(model_name)
-    _current_model = name
-    logger.info("Selected STT model: %s", name)
-
-
-def get_selected_model() -> str | None:
-    return _current_model
-
-
 def transcribe_audio(samples) -> Tuple[str, float]:
+    """Transcribe audio samples using the Whisper base model."""
     global _engine
     if _engine is None:
-        models = list_models()
-        if models:
-            select_model(models[0])
-        else:
-            _engine = whisper.load_model("base")
-            _current_model = "base"
+        _engine = whisper.load_model("base")
+        logger.info("Loaded Whisper base model for STT")
     logger.debug("Transcribing %d samples", len(samples))
     result = _engine.transcribe(samples, fp16=False)
     text = result.get("text", "").strip()

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,6 +20,18 @@
     </nav>
 </header>
 <main class="chat-wrapper">
+    <div class="stt-container">
+        <h2>Speech Input</h2>
+        <div id="stt-output" class="stt-text"></div>
+        <div id="tooltip" class="tooltip" style="display:none;"></div>
+    </div>
+    <div class="ai-response">
+        <textarea id="ai-output" rows="3"></textarea>
+        <div class="ai-controls">
+            <button type="button" id="speak-now">Speak</button>
+            <button type="button" id="stop-speak" style="display:none;">Stop</button>
+        </div>
+    </div>
     <div class="messages"></div>
     <form class="input-area">
         <input type="text" placeholder="Send your message" />

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -54,13 +54,6 @@
             </div>
         </label>
 
-        <label>
-            Select Speech-to-Text Model
-            <div style="display: flex; flex-wrap: wrap; gap: 10px;">
-                <select id="stt-select"></select>
-                <button id="reload-stt" type="button">Reload Models</button>
-            </div>
-        </label>
     </div>
 
     <div class="settings-section">

--- a/app/templates/testing.html
+++ b/app/templates/testing.html
@@ -25,8 +25,9 @@
     </div>
     <div class="tab-content" id="stt-tab">
         <button id="test-mic" class="mic-btn">🎤</button>
+        <div class="voice-indicator" id="voice-indicator"></div>
         <canvas id="test-wave" width="300" height="80"></canvas>
-        <div id="test-transcript" class="test-transcript"></div>
+        <textarea id="test-transcript" class="test-transcript" rows="3" readonly></textarea>
     </div>
     <div class="tab-content" id="tts-tab" style="display:none;">
         <input type="text" id="tts-input" placeholder="Type something to speak..." />


### PR DESCRIPTION
## Summary
- default STT to Whisper and remove dynamic model selection
- simplify settings page and client scripts
- show live STT output on chat page
- add listening indicator and transcript box on testing page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b54461408326a96602b57be7405f