### PR TITLE
Fix microphone streaming error

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -159,8 +159,14 @@ function beginStreaming(stream) {
 
     mediaRecorder = new MediaRecorder(stream);
     mediaRecorder.addEventListener('dataavailable', (event) => {
-        if (event.data.size > 0 && ws.readyState === WebSocket.OPEN) {
+        if (event.data.size > 0 && ws && ws.readyState === WebSocket.OPEN) {
             ws.send(event.data);
+        }
+    });
+    mediaRecorder.addEventListener('stop', () => {
+        if (ws) {
+            ws.close();
+            ws = null;
         }
     });
     mediaRecorder.start(250);
@@ -172,8 +178,7 @@ function stopStreaming() {
     if (mediaRecorder) {
         mediaRecorder.stop();
         mediaRecorder = null;
-    }
-    if (ws) {
+    } else if (ws) {
         ws.close();
         ws = null;
     }


### PR DESCRIPTION
## Summary
- ensure `ws` exists before checking `readyState`
- wait for MediaRecorder `stop` event to close websocket
- only close websocket when recorder isn't active

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854c5790c188326ab8d7a5e88c68642